### PR TITLE
Fix navigation problem in Kodi 18

### DIFF
--- a/default.py
+++ b/default.py
@@ -61,6 +61,8 @@ if params:
             xbmc.executebuiltin('Container.Refresh')
         elif params['action'] == 'buy':
             nav.playAsset(params['id'])
+    else:
+        nav.mainMenu()
 else:
     nav.mainMenu()
 


### PR DESCRIPTION
Kodi 18 introduces a new parameter when launching plugin (content-type: video) which the plugins router couldn't cope with. A simple else condition on the second level of the routing function fixes that issue.